### PR TITLE
refactor: update oninit

### DIFF
--- a/TigerTango/TigerTango.xml
+++ b/TigerTango/TigerTango.xml
@@ -2211,7 +2211,7 @@ set $cycleWave1 0
 			</button>
 			<button class="button_main" text="⚠️" query="not crossfader_disable"
 			textsize="14" x="+200+2" y="+53" height="25" width="35"
-				action="crossfader_disable">
+				action="crossfader_disable on">
 				<tooltip>Crossfader is enabled which can cause TigerTango to not output sound. Click to disable Crossfader.</tooltip>
 			</button>
 			<button class="button_main" text="⚠️" query="deck 1 fader_start ? true : deck 2 fader_start"


### PR DESCRIPTION
The oninit actions were not always working. Update makes oninit work more reliably.
* Adds a 0.3 second wait time to initiate (avoids initializing before skin fully loads)
* updates crossfade_disable (a toggle) to crossfade_disble on (sets it to always disable)

Update makes is safer to switch between skins (avoids lingering crossfade_disable) 