### PR TITLE
Update single-dual-deck switch

### DIFF
--- a/TigerTango/TigerTango.xml
+++ b/TigerTango/TigerTango.xml
@@ -2175,7 +2175,7 @@ set $cycleWave1 0
 <!-- setting 'automixDualDeck' ? 'D' :  -->
 			<button class="button_main" textaction="automix_dualdeck ? get_text 'D' : get_text 'S'" query="false"
 			textsize="14" x="+200+80" y="+23" height="25" width="35"
-				action="automix_dualdeck ? automix_dualdeck off : automix_dualdeck on">
+				action="automix_dualdeck ? automix_dualdeck off : (automix_dualdeck on & deck 1 play ? deck 2 load_next : deck 1 load_next)">
 				<tooltip>Click to toggle between 'Single' and 'Dual Deck' automix mode. </tooltip>
 			</button>
 			<!-- "" -->


### PR DESCRIPTION
PR updates behavior when switching from single to dual deck using button.

Issue was that in previous behavior, if the second deck had a song that was not part of the automix, then when switching from single to dual deck this song would be cued next. 

PR updates behavior to load next automix song on the idle deck when switching to dual deck