### PR TITLE
fix: single to dual button

### DIFF
--- a/TigerTango/TigerTango.xml
+++ b/TigerTango/TigerTango.xml
@@ -2175,7 +2175,7 @@ set $cycleWave1 0
 <!-- setting 'automixDualDeck' ? 'D' :  -->
 			<button class="button_main" textaction="automix_dualdeck ? get_text 'D' : get_text 'S'" query="false"
 			textsize="14" x="+200+80" y="+23" height="25" width="35"
-				action="automix_dualdeck ? automix_dualdeck off : (automix_dualdeck on & deck 1 play ? deck 2 load automix_song : deck 1 load automix_song)">
+				action="automix_dualdeck ? automix_dualdeck off : (deck 1 play ? deck 2 unload : deck 1 unload) & automix_dualdeck on)">
 				<tooltip>Click to toggle between 'Single' and 'Dual Deck' automix mode. </tooltip>
 			</button>
 			<!-- "" -->


### PR DESCRIPTION
* Previous use of load_next would fail if user was not looking at the automix browser (no good)
*Use of automix 1 was skipping a track (no good either)

PR uses approach that seems to work. 
When switching from single to dual deck, first unload track on idle deck, then switch to dual deck. 
This allows the dual deck to load the next track in the automix on the free deck