### PR TITLE
feature change: AUTO button functionality

### DIFF
--- a/TigerTango/TigerTango.xml
+++ b/TigerTango/TigerTango.xml
@@ -2058,8 +2058,14 @@ set $cycleWave1 0
 
 			<button class="button_main" text="AUTO" width="64" height="40" x="+0" y="+55" textsize = "16"
 					action="deck master automix ? deck master automix off :
-							deck 2 play ? deck 2 automix_load & automix on :
-							deck 1 automix_load & automix on"
+							automix_dualdeck ? (
+								deck 2 play ?
+									deck 1 unload & deck 2 automix_load & automix on :
+									deck 1 automix_load & deck 2 unload & deck 1 play & automix on ): (
+								deck 2 play ?
+									deck 2 automix_load & automix on :
+									deck 1 automix_load & deck 1 play & automix on)
+								 "
 							query="deck master automix">
 				<tooltip>AUTO PLAYBACK\nToggle auto playback (Automix).\n Next song will be loaded on other deck and automatically cued.</tooltip>
 			</button>
@@ -2373,9 +2379,15 @@ set $cycleWave1 0
 
 			<button class="button_main" text="AUTO" width="64" height="40" x="+0" y="+55" textsize = "16"
 				action="deck master automix ? deck master automix off :
-							deck 1 play ? deck 1 automix_load & automix on :
-							deck 2 automix_load & automix on"
+						automix_dualdeck ? (
+							deck 1 play ?
+								deck 1 unload & deck 2 automix_load & automix on :
+								deck 2 automix_load & deck 1 unload & deck 2 play & automix on) : (
+							deck 1 play ?
+								deck 1 automix_load & automix on :
+								deck 1 automix_load & deck 1 play & automix on)"
 							query="deck master automix">
+
 				<tooltip>AUTO PLAYBACK\nToggle auto playback (Automix).\n Next song will be loaded on other deck and automatically cued.</tooltip>
 			</button>
 


### PR DESCRIPTION
PR updates how the AUTO functionality works for dual deck. 

Current functionality uses same functionality as the automix button. With dual deck this has the property of playing whatever is loaded into the other deck, and then starting the playlist from this position.
If a song is loaded onto the other deck which is not next in the automix, then pressing AUTO will not follow the automix playlist. 

PR updates to unload the other deck and load whatever is next in the automix playlist. 

Video shows example: 
1. pressing automix button does not update other deck
2. pressing AUTO button now does update other deck

https://github.com/user-attachments/assets/d185be33-2033-432b-9c6f-95cc9d8f51ce

This PR is to help make dual deck behave more similarly to how dual deck behaves. It also fits in line with the workflow tango DJs would most likely use after a performance. 
1. Turn off automix before performance
2. load individual songs for performance
3. after performance, load song that they want to start automix from and hit AUTO. this will now start the playlist from this spot. 



