### PR TITLE
Incorporate-large-preview-toggle

### DIFF
--- a/TigerTango/TigerTango.xml
+++ b/TigerTango/TigerTango.xml
@@ -1264,6 +1264,7 @@ set $cycleWave1 0
 						<size width="6" height="58"/>
 						<on color="knobfill" shape="square" border_size="1" border="bordercolor" radius="33"/>
 					</visual>
+					<panel name="coverart_video" visibility="is_video 'active'">
 						<video x="+13" y="+13" source="deck" letterboxing="crop" linkdrop="false">
 							<size width="186" height="186"/>
 							<clipmask x="776" y="216" width="184" height="184"/>
@@ -1734,28 +1735,46 @@ set $cycleWave1 0
 				<size width="110" height="16"/>
 				<text fontsize="12" align="center" color="textdarker" text="Click to activate" localize="true" important="true"/>
 			</textzone>
-			<video x="+1" y="+1" source="master">
+			<video x="+1" y="+1" source="master" visibility="not var '$largeVideo'">
 				<size width="110" height="84"/>
 			</video>
-			<button x="+0" y="+0" action="video" rightclick="video_output">
-				<size width="110" height="84"/>
+			<video x="+0" y="-30" source="master" visibility="var '$largeVideo'">
+				<size width="315" height="185"/>
+
+			</video>
+			<button x="+0" y="+0"
+				action="video"
+				rightclick="not video ? video_output: toggle '$largeVideo'"
+				visibility="not video ? true : not var '$largeVideo' ? true : false"
+				dblclick="video & set '$largeVideo' 1">
+				<size width="106" height="85"/>
+				<tooltip>Click to toggle video. When video is inactive, right click to video output. When video is active, right click to toggle large video preview.</tooltip>
+			</button>
+			<button x="+0" y="-30"
+			action="video"
+			rightclick="toggle '$largeVideo'"
+			visibility="video && var '$largeVideo'">
+			<size width="315" height="185"/>
+			<tooltip>Click to toggle video. When video is inactive, right click to video output. When video is active, right click to toggle large video preview.</tooltip>
 			</button>
 		</group>
 
 
-		<group name="videomix" x="+0" y="+0" visibility="has_video_mix">
-			<panel class="vfxdrop" width="+110" x="+35" y="+73" action1="video_transition" rightclick="video_transition 500ms" action2="video_transition_select" textaction="get_videotrans_name &amp; param_uppercase"/>
+		<group name="videomix" x="+0" y="+0" visibility="video ? var '$largeVideo' ? false : has_video_mix : has_video_mix">
+			<panel class="vfxdrop" width="+110" x="+35" y="+73" action1="video_transition"
+						rightclick="video_transition 500ms" action2="video_transition_select"
+						textaction="get_videotrans_name &amp; param_uppercase"/>
 			<!-- <panel class="settingsbutton" width="+135" x="+30" y="+40" action1="deck master video_" action2="deck master video__select" textaction="deck master get_video_name &amp; param_uppercase"/> -->
-			<panel class="vfxdrop" width="+110" x="+73" y="+104" action1="deck master video_fx" action2="deck master video_fx_select" textaction="deck master get_videofx_name &amp; param_uppercase"/>
+			 <panel class="vfxdrop" width="+110" x="+35" y="+104" action1="deck master video_fx" action2="deck master video_fx_select" textaction="deck master get_videofx_name &amp; param_uppercase"/>
 
-			<button class="settingsbutton" x="+35" y="+110" action="video_output" query="false"/>
-		</group>
-		<group name="videosimple" x="+0" y="+0" visibility="not has_video_mix">
-			<panel class="vfxdrop" width="+110" x="+35" y="+73"  action1="video_source" action2="video_source_select" textaction="get_text '%videosource' &amp; param_uppercase"/>
-			<panel class="vfxdrop" width="+110" x="+35" y="+104"  action1="deck master video_fx" action2="deck master video_fx_select 'no_sources'" textaction="deck master get_videofx_name &amp; param_uppercase"/>
-			<!-- <panel class="vdrop" width="+135" x="+30" y="+50"  action1="deck master video_" action2="deck master video__select 'no_sources'" textaction="deck master get_video_name &amp; param_uppercase"/> -->
 			<!-- <button class="settingsbutton" x="+35" y="+110" action="video_output" query="false"/> -->
 		</group>
+		<group name="videosimple" x="+0" y="+0" visibility="video ? var '$largeVideo' ? false : not has_video_mix : not has_video_mix">
+			<panel class="vfxdrop" width="+110" x="+35" y="+73"  action1="video_source" action2="video_source_select" textaction="get_text '%videosource' &amp; param_uppercase"/>
+			<panel class="vfxdrop" width="+110" x="+35" y="+104"  action1="deck master video_fx" action2="deck master video_fx_select 'no_sources'" textaction="deck master get_videofx_name &amp; param_uppercase"/>
+			<!-- <panel class="vdrop" width="+135" x="+30" y="+40"  action1="deck master video_" action2="deck master video__select 'no_sources'" textaction="deck master get_video_name &amp; param_uppercase"/> -->
+			<!-- <button class="settingsbutton" x="+35" y="+110" action="video_output" query="false"/> -->
+			</group>
 	</panel>
 	</group>
 </group>


### PR DESCRIPTION
PR implements great proposal suggested in #23 of allowing video preview to be larger along with fixing a bug introduced in pull #24. 

In #23 Hartag notes that "The video preview in TigerTango is too small to be able to clearly read information displayed on the external screen." Solution is to allow a larger preview to be toggled. 

This PR implements a slightly different logic to get the same effect. 
By switching the video output selection button with the video effects button (to allow things like text to be added to video), the only way to get the video output is the right click on the video area. To make this easier to do, this PR implements the following logic:
* If no video is active, then right click opens the video output selection menu. 
* If video is active, then right click toggles the larger video screen. 
* If you click on the video then it will turn off the video preview, leaving the size toggle at whatever was previously set (so if you set to larger preview and then close preview, next time you open it will be larger).