### PR TITLE
Update toolbox

### DIFF
--- a/TigerTango/TigerTango.xml
+++ b/TigerTango/TigerTango.xml
@@ -2207,7 +2207,9 @@ set '$cycleWave1' 0
 			<button class="button_main" textaction="automix_dualdeck ? get_text 'D' : get_text 'S'" query="false"
 			textsize="14" x="+200+80" y="+23" height="25" width="35"
 			action="
-			(deck 1 play ? set '$decksPaused' 0 : deck 2 play ? set '$decksPaused' 0 : set '$decksPaused' 1) &
+			set '$decksPaused' 1 &
+				(deck 1 play ? set '$decksPaused' 0 : nothing) &
+				(deck 2 play ? set '$decksPaused' 0 : nothing) &
 				(automix_dualdeck ? automix_dualdeck off :
 					((deck 1 play ? deck 2 load automix_song 1 : deck 1 load automix_song 1) & automix_dualdeck on)
 				) &
@@ -2216,10 +2218,9 @@ set '$cycleWave1' 0
 			</button>
 			<!-- "" -->
 			<!-- ___________ Row 2 of warnings _________________  -->
-			set '$autoDblClickInd' 1
-			<button class="button_main" text="⚠️" query="(var_equal '$autoDblClickInd' 0) ? false : not setting 'automixDoubleCLick' 'nothing' ? true: false"
+			<button class="button_main" text="⚠️" query="var_equal '$ignoreDblClickInd' 1 ? false : not setting 'automixDoubleCLick' 'nothing' ? true: false"
 			textsize="14" x="+7" y="+53" height="25" width="35"
-				action="setting 'automixDoubleCLick' 'nothing'" rightclick="toggle '$autoDblClickInd'">
+				action="setting 'automixDoubleCLick' 'nothing'" rightclick="toggle '$ignoreDblClickInd'">
 				<tooltip>Recommended to set automixDoucleClick to 'nothing'. Click to change settings. Right click to toggle warning light.</tooltip>
 			</button>
 
@@ -2245,15 +2246,20 @@ set '$cycleWave1' 0
 				action="setting 'fadeLength' 0 & setting 'fadeLength' -3" rightclick="setting 'fadeLength' 0">
 				<tooltip>Automix 'fadeLength' setting is above 0, meaning the end of tracks could be cut. Click to set to -3 (a 3 second gap between songs). Right click to set to 0.</tooltip>
 			</button>
-			<button class="button_main" text="⚠️" query="not crossfader_disable"
+			<button class="button_main" text="⚠️" query="not crossfader_disable ? true : deck 1 fader_start ? true : tdeck 2 fader_start"
 			textsize="14" x="+200+2" y="+53" height="25" width="35"
-				action="crossfader_disable on">
-				<tooltip>Crossfader is enabled which can cause TigerTango to not output sound. Click to disable Crossfader.</tooltip>
+				action="crossfader_disable on & deck 1 fader_start off & deck 2 fader_start off">
+				<tooltip>Crossfader or Fader Start is enabled. This can cause TigerTango to not work properly. Click to disable Crossfader and Fader Start.</tooltip>
 			</button>
-			<button class="button_main" text="⚠️" query="deck 1 fader_start ? true : deck 2 fader_start"
+			<button
+				class="button_main" text="⚠️"
+				query="var_equal '$ignoreCueSettingsInd' 1 ? false :
+					(not setting 'autoSortCues' ? true :
+						(deck 1 setting 'smartLoop' on ? true : deck 2 setting 'smartLoop' on ? true : false))"
+				rightclick="toggle '$ignoreCueSettingsInd'"
 			textsize="14" x="+200+40+1" y="+53" height="25" width="35"
-				action="deck 1 fader_start off & deck 2 fader_start off">
-				<tooltip>Fader Start is turned on. This will conflict with the fade and volume controls. Click to turn off Fader Start.</tooltip>
+				action="setting 'autoSortCues' on & deck 1 setting 'smartLoop' off & deck 2 setting 'smartLoop' off">
+				<tooltip>Click to change to recommended settings 'smartLoop' off and autoSortCues on. This ensures loop button will work as expected. Right click to ignore warning.</tooltip>
 			</button>
 			<button class="button_main" text="⚠️" query="auto_pitch_lock ? true : auto_match_key ? true : auto_pitch_lock ? true : not setting 'autoBPMMatch' 'no'"
 			textsize="14" x="+200+80" y="+53" height="25" width="35"
@@ -2261,8 +2267,6 @@ set '$cycleWave1' 0
 				<tooltip>Auto match BPM, key, or pitch is turned on. This will affect sound quality. Click to turn these settings off.</tooltip>
 			</button>
 		</group>
-
-
 </deck>
 </panel>
 <panel name="deckright" x="1920-764" y="80" width="764" height="389">
@@ -2651,7 +2655,6 @@ set '$cycleWave1' 0
 <oninit action="setting_setdefault coverflow 'smart'"/>
 <oninit action="setting_setdefault browserPadding 50%"/>
 <oninit action="deck all effect_3slots_layout off"/>
-<oninit action="setting 'smartPlay' off & setting_setdefault smartPlay off"/>
 <oninit action="repeat_start 'WaitTimer' 300ms 1 &
 			crossfader_disable on &
 			deck 1 'faderStart' 'off' & deck 2 'faderStart' 'off' &
@@ -2668,6 +2671,8 @@ set '$cycleWave1' 0
 			setting_setdefault equalizerMidFrequency 1000 &
 			setting_setdefault equalizerHighFrequency 8500 &
 			setting_setdefault cpuMeter 'system' &
-			setting_setdefault masterTempo 'no'
+			setting_setdefault masterTempo 'no' &
+			setting 'autoSortCues' on &
+			deck 1 setting 'smartLoop' off & deck 2 setting 'smartLoop' off
 					"/>
 </skin>


### PR DESCRIPTION
PR updates toolbox

* Update pause check for single - dual deck button (still needs some work)
* Fix 'automixDoubleClick' toggle problem (now defaults to showing issue instead of defaulting to not showing)
* Combine crossfade and fader start  check
* Use new spot to add Loop and Cue checks
* Add setting 'autoSortCues' on and deck 1 setting 'smartLoop' off & deck 2 setting 'smartLoop' off to oninit