### PR TITLE
Update auto button default

### DIFF
--- a/TigerTango/TigerTango.xml
+++ b/TigerTango/TigerTango.xml
@@ -2079,15 +2079,15 @@ set '$fadeIndicator1' 0
 			<!-- _________ROW 2 ______________ -->
 
 			<button class="button_main" text="AUTO" width="64" height="40" x="+0" y="+55" textsize = "16"
-					action="deck 1 automix ? deck 1 automix off :
-							deck 2 automix ? deck 2 automix off :
+					action="deck 1 automix ? deck 1 automix off : deck 2 automix ? deck 2 automix off :
 							automix_dualdeck ? (
-								deck 2 play ?
-									deck 1 unload & deck 2 automix_load & automix on :
-									deck 1 automix_load & deck 2 unload & deck 1 play & automix on ): (
-								deck 2 play ?
-									deck 2 automix_load & automix on :
-									deck 1 automix_load & deck 1 play & automix on)
+								deck 2 play ? (deck 1 unload & deck 2 automix_load & automix on) :
+								( (deck 1 loaded ? deck 1 automix_load : deck 1 load automix_song 1)
+								 	& deck 2 unload & deck 1 play & automix on)
+							): (
+								deck 2 play ? deck 2 automix_load & automix on :
+								(deck 1 loaded ? deck 1 automix_load : deck 1 load automix_song 1)
+									& deck 1 play & automix on)
 								 "
 							query="deck 1 automix ? true : deck 2 automix ? true : false">
 				<tooltip>AUTO PLAYBACK\nToggle auto playback (Automix).\n Next song will be loaded on other deck and automatically cued.</tooltip>
@@ -2412,15 +2412,16 @@ set '$fadeIndicator1' 0
 			</button>
 				<!-- _________ROW 2 ______________ -->
 			<button class="button_main" text="AUTO" width="64" height="40" x="+0" y="+55" textsize = "16"
-				action="deck 1 automix ? deck 1 automix off :
-						deck 2 automix ? deck 2 automix off :
+				action="deck 1 automix ? deck 1 automix off : deck 2 automix ? deck 2 automix off :
 						automix_dualdeck ? (
-							deck 1 play ?
-								deck 2 unload & deck 1 automix_load & automix on :
-								deck 2 automix_load & deck 1 unload & deck 2 play & automix on) : (
-							deck 1 play ?
-								deck 1 automix_load & automix on :
-								deck 2 automix_load & deck 2 play & automix on)"
+							deck 1 play ? (deck 2 unload & deck 1 automix_load & automix on) :
+							( (deck 2 loaded ? deck 2 automix_load : deck 2 load automix_song 1)
+							 	& deck 1 unload & deck 2 play & automix on)
+						): (
+							deck 1 play ? deck 1 automix_load & automix on :
+							(deck 2 loaded ? deck 2 automix_load : deck 2 load automix_song 1)
+								& deck 2 play & automix on)
+							"
 							query="deck 1 automix ? true : deck 2 automix ? true : false">
 
 				<tooltip>AUTO PLAYBACK\nToggle auto playback (Automix).\n Next song will be loaded on other deck and automatically cued.</tooltip>


### PR DESCRIPTION
PR updates auto button such that if no song is loaded onto deck then it defaults to the first automix song. 

Previous button was defaulting to load whatever was highlighted in browser at the first automix if the deck had nothing loaded. This could cause confusion, hence the update. 

This means AUTO now uses the following logic:

- Other deck playing? have that song as first automix and load next song in list
- No track loaded --> load first song in automix list
- Track loaded ? load this to automix and have it be first in line. 